### PR TITLE
Make "Entry" protected for extension.

### DIFF
--- a/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
+++ b/src/main/java/com/jakewharton/disklrucache/DiskLruCache.java
@@ -885,7 +885,7 @@ public final class DiskLruCache implements Closeable {
     }
   }
 
-  private final class Entry {
+  protected final class Entry {
     private final String key;
 
     /** Lengths of this entry's files. */


### PR DESCRIPTION
In my case, I need to get File in the cache instead of the FileInputStream. But with the "private" limitation, it's not possible to get such information.
